### PR TITLE
Add optional crowbar-applied boolean attribute to schema

### DIFF
--- a/chef/data_bags/crowbar/bc-template-nfs_client.json
+++ b/chef/data_bags/crowbar/bc-template-nfs_client.json
@@ -9,6 +9,7 @@
   "deployment": {
     "nfs_client": {
       "crowbar-revision": 0,
+      "crowbar-applied": false,
       "element_states": {
         "nfs-client": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/bc-template-nfs_client.schema
+++ b/chef/data_bags/crowbar/bc-template-nfs_client.schema
@@ -42,6 +42,7 @@
           "mapping": {
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
+	    "crowbar-applied": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },
             "crowbar-status": { "type": "str" },
             "crowbar-failed": { "type": "str" },

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -26,4 +26,4 @@ crowbar:
   order: 55
   run_order: 55
   chef_order: 55
-  proposal_schema_version: 2
+  proposal_schema_version: 3


### PR DESCRIPTION
We add a crowbar applied attribute to mark the proposal as applied after
the chef run. This allows the UI to show that the current form of the
proposal has been 'applied' successfully (i.e. chef-client completed the
run w/ success) and that the proposal was not modified after that.

Update the proposal_schema_revision, so we can add the attribute to
schema for ('3rd party') barclamps that currently do not have it.

Refs: crowbar/crowbar#2044 (which adds this attribute to barclamps which
lack it), crowbar/barclamp-crowbar#1068 (which marks the proposals as
applied) and https://bugzilla.novell.com/show_bug.cgi?id=877486
